### PR TITLE
Add <algorithm> include for std::{min,max}

### DIFF
--- a/lib/file.cpp
+++ b/lib/file.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #define FSTR(x) static_cast<std::fstream*>(x)
 #endif
+#include <algorithm>
 
 namespace si {
 


### PR DESCRIPTION
`lib/file.cpp` uses `std::min`, which is provided by [the `<algorithm>` header](https://en.cppreference.com/w/cpp/algorithm/min.html).

This should fix the following errors (untested):
```
 D:\a\isle-portable\isle-portable\build\3rdparty\libweaver-src\lib\file.cpp(285): error C2589: '(': illegal token on right side of '::'
D:\a\isle-portable\isle-portable\build\3rdparty\libweaver-src\lib\file.cpp(285): error C2059: syntax error: ')'
D:\a\isle-portable\isle-portable\build\3rdparty\libweaver-src\lib\file.cpp(288): error C2589: '(': illegal token on right side of '::'
D:\a\isle-portable\isle-portable\build\3rdparty\libweaver-src\lib\file.cpp(288): error C2059: syntax error: ')'
D:\a\isle-portable\isle-portable\build\3rdparty\libweaver-src\lib\file.cpp(303): error C2589: '(': illegal token on right side of '::'
D:\a\isle-portable\isle-portable\build\3rdparty\libweaver-src\lib\file.cpp(303): error C2059: syntax error: ')'
```

[See this ci run](https://github.com/isledecomp/isle-portable/actions/runs/19599481147/job/56128871549#step:19:362)